### PR TITLE
fix(exp::compiler::types) - Capitalize function case

### DIFF
--- a/exp/compiler/types.cpp
+++ b/exp/compiler/types.cpp
@@ -264,7 +264,7 @@ GetBaseTypeName(Type* type)
   if (type->isUnresolvable())
     return "<unresolved>";
   if (type->isMetaFunction())
-    return "function";
+    return "Function";
   if (type->isUnchecked())
     return "any";
   if (type->isVoid() || type->isImplicitVoid())


### PR DESCRIPTION
A funky fix that makes function casing compatible with v1 comp